### PR TITLE
Rename abelsiqueira/asreview-cloud to asreview/cloud-usage

### DIFF
--- a/20-parallel.md
+++ b/20-parallel.md
@@ -44,7 +44,7 @@ To do that, we need the [split-file.py](code/split-file.py) script included in t
 To directly download it from the internet, you can issue the following command:
 
 ```bash
-wget https://raw.githubusercontent.com/abelsiqueira/asreview-cloud/main/code/split-file.py
+wget https://raw.githubusercontent.com/asreview/cloud-usage/main/code/split-file.py
 ```
 
 Now run the following to split on the jobs.sh file into three files:
@@ -65,7 +65,7 @@ To simplify your usage, we have created the script [parallel_run.sh](code/parall
 Download it issuing
 
 ```bash
-wget https://raw.githubusercontent.com/abelsiqueira/asreview-cloud/main/code/parallel_run.sh
+wget https://raw.githubusercontent.com/asreview/cloud-usage/main/code/parallel_run.sh
 ```
 
 Then you can just run the script below, specifying the number of cores as an argument.

--- a/30-many-jobs.md
+++ b/30-many-jobs.md
@@ -24,7 +24,7 @@ For instance, we could write
 Now, download the file [many-jobs.sh](code/many-jobs.sh):
 
 ```bash
-wget https://raw.githubusercontent.com/abelsiqueira/asreview-cloud/main/code/many-jobs.sh
+wget https://raw.githubusercontent.com/asreview/cloud-usage/main/code/many-jobs.sh
 ```
 
 This file should contain something like

--- a/40-kubernetes.md
+++ b/40-kubernetes.md
@@ -62,8 +62,8 @@ The "single computer" strategy can also be followed to test your scripts before 
 In both cases, start by cloning this repo, as you will need the configuration files provided here:
 
 ```bash
-git clone https://github.com/abelsiqueira/asreview-cloud
-cd asreview-cloud
+git clone https://github.com/asreview/cloud-usage
+cd cloud-usage
 ```
 
 All the `.yml` files that you need to run below are inside the `k8-config` folder.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# asreview-cloud (Running simulations on the cloud and/or in parallel)
+# Running simulations on the cloud and/or in parallel
 
 This repository houses some files to help run simulations on the cloud, i.e., outside your computer, possibly in parallel.
 We assume that you know how to run simulations on your computer using [Makita](https://github.com/asreview/asreview-makita).


### PR DESCRIPTION
This repository was at my user name (`abelsiqueira`) and I have transferred it to `asreview`, and the name has been changed from `asreview-cloud` to `cloud-usage`. 

Closes #19 